### PR TITLE
Compatibility with Ruby 1.8

### DIFF
--- a/lib/puppet/provider/cumulus_ports/cumulus.rb
+++ b/lib/puppet/provider/cumulus_ports/cumulus.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:cumulus_ports).provide :cumulus do
   # "Could not find a suitable provider for cumulus_ports"
   # someone asked for a way to log why provider is not suitable
   # but unable to find progress on it. http://bit.ly/17Dhny6
-  confine operatingsystem: [:cumuluslinux]
+  confine :operatingsystem => [:cumuluslinux]
 
   def self.file_path
     '/etc/cumulus/ports.conf'
@@ -44,10 +44,10 @@ Puppet::Type.type(:cumulus_ports).provide :cumulus do
 
   def self.portattrs
     {
-      speed_10g: '10G',
-      speed_40g: '40G',
-      speed_4_by_10g: '4x10G',
-      speed_40g_div_4: '40G/4'
+      :speed_10g => '10G',
+      :speed_40g => '40G',
+      :speed_4_by_10g => '4x10G',
+      :speed_40g_div_4 => '40G/4'
     }
   end
 

--- a/spec/acceptance/ports_spec.rb
+++ b/spec/acceptance/ports_spec.rb
@@ -18,7 +18,7 @@ describe 'ports' do
         }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, :catch_failures => true)
     end
 
     describe file('/etc/cumulus') do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,9 +21,9 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module
-    puppet_module_install(source: module_root, module_name: 'cumulus_ports')
+    puppet_module_install(:source => module_root, :module_name => 'cumulus_ports')
     hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), :acceptable_exit_codes => [0, 1]
     end
   end
 end

--- a/spec/unit/provider/cumulus_ports/base_spec.rb
+++ b/spec/unit/provider/cumulus_ports/base_spec.rb
@@ -9,11 +9,11 @@ describe provider_class do
     # resource parameters require to be in arrays!!
     # wonder if I can get away from this requirement
     @resource = provider_resource.new(
-      name: 'speeds',
-      speed_4_by_10g: 'swp1-2',
-      speed_40g: ['swp3'],
-      speed_40g_div_4: %w(swp4 swp6),
-      speed_10g: ['swp10']
+      :name => 'speeds',
+      :speed_4_by_10g => 'swp1-2',
+      :speed_40g => ['swp3'],
+      :speed_40g_div_4 => %w(swp4 swp6),
+      :speed_10g => ['swp10']
     )
     @provider = provider_class.new(@resource)
   end

--- a/spec/unit/type/cumulus_ports_spec.rb
+++ b/spec/unit/type/cumulus_ports_spec.rb
@@ -36,7 +36,7 @@ describe cl_ports do
       @provider = double 'provider'
       allow(@provider).to receive(:name).and_return(:cumulus)
       cl_ports.stubs(:defaultprovider).returns @provider
-      @cumulus_ports = cl_ports.new(name: 'speeds')
+      @cumulus_ports = cl_ports.new(:name => 'speeds')
     end
     subject { allow(@cumulus_ports.provider).to receive(:config_changed?) }
     let(:ensure_result) { @cumulus_ports.property(:ensure).retrieve }


### PR DESCRIPTION
When Puppet master is running on an old installation running Ruby 1.8 (Ubuntu Precise, CentOS 6), this module doesn't work because of the new-style hash (introduced in Ruby 1.9). This PR reverts to old-style hash to brings back Ruby 1.8 compatibility.

Most Puppet modules seem to stick to Ruby 1.8 compatibility (first time I got this problem). However, feel free to just close the PR if you are not interested. People needing it will likely find it.